### PR TITLE
Mark MiniTube as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application relies on an old runtime that was marked as end-of-life (EOL) 2 years ago.

https://github.com/flathub/org.tordini.flavio.Minitube/issues/23